### PR TITLE
Add content to anchors to satisfy a11y concern

### DIFF
--- a/src/components/GroupLink.js
+++ b/src/components/GroupLink.js
@@ -2,7 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const GroupLink = ({ url, description, icon }) => (
-  <a href={url} target="group" rel="nofollow" className={icon} title="This group’s {description}"></a>
+  <a href={url} target="group" rel="nofollow" className={icon}>
+    <span style={{ display: "none" }}>{description}</span>
+  </a>
 );
 
 GroupLink.propTypes = {


### PR DESCRIPTION
This resolves an accessibility concern reintroduced in e28bde0044618a36d3179d52d60a6e90fc0a40bf:

> Anchors must have content and the content must be accessible by a screen reader

@adamculpepper, I think should resolve the issue in a way such that there are no longer any layout artifacts in Chrome. Let me know!